### PR TITLE
Fix tar exclude options

### DIFF
--- a/Command/BackupCommand.php
+++ b/Command/BackupCommand.php
@@ -89,13 +89,13 @@ class BackupCommand extends StorageCommand
         }, $ignoreFilesOption);
 
         $ignoreFiles[] = 'app/config/local';
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_CACHE_DIRECTORY);
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_SYMFONY_CACHE_DIRECTORY);
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_WEB_ROOT).'/var/tmp';
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_SYSTEM_TEMP_DIRECTORY);
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_PRIVATE_VAR).'/sessions';
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_LOG_FILEOBJECT_DIRECTORY);
-        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.' / ', '', PIMCORE_LOG_DIRECTORY);
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_CACHE_DIRECTORY);
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_SYMFONY_CACHE_DIRECTORY);
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_WEB_ROOT).'/var/tmp';
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_SYSTEM_TEMP_DIRECTORY);
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_PRIVATE_VAR).'/sessions';
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_LOG_FILEOBJECT_DIRECTORY);
+        $ignoreFiles[] = str_replace(PIMCORE_PROJECT_ROOT.'/', '', PIMCORE_LOG_DIRECTORY);
         $ignoreFiles = array_map(static function($path) {
             return '--exclude "'.$path.'"';
         }, $ignoreFiles);


### PR DESCRIPTION
Currently the Pimcore project root is not removed from the exclude options provided to the `tar` command. This makes the backup file quite large because unwanted files are added to the archive (even the temporary archive file itself because it is located in `var/tmp`).

This is caused by spaces around the directory separator in the `str_replace` calls in the backup command.

To fix this, the invalid spaces are removed.

